### PR TITLE
Make the GitHub button link to correct page

### DIFF
--- a/index.md
+++ b/index.md
@@ -157,5 +157,5 @@ data:
       actions:
         - text: '<i class="fab fa-github"></i> GitHub'
           type: secondary
-          url: https://github.com/kitian616/jekyll-TeXt-theme
+          url: https://github.com/web-cat
 ---


### PR DESCRIPTION
The GitHub button under the text "Clone our work, fork it, customize it, and send us improvements!" links to the theme used for the webpage. I've changed it to link to the organization account.

A link to the theme is still present in the footer "Powered by Jekyll & TeXt Theme."